### PR TITLE
Update kotlin ipv8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlint_gradle_version"
         classpath "com.squareup.sqldelight:gradle-plugin:$sqldelight_version"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.3.72'
     ext.ktlint_version = '0.36.0'
     ext.ktlint_gradle_version = '9.1.1'
     ext.sqldelight_version = '1.2.2'

--- a/common/src/test/java/nl/tudelft/trustchain/common/util/VotingHelperTest.kt
+++ b/common/src/test/java/nl/tudelft/trustchain/common/util/VotingHelperTest.kt
@@ -50,7 +50,6 @@ class VotingHelperTest {
         community.endpoint = getEndpoint()
         community.network = Network()
         community.maxPeers = 20
-        community.cryptoProvider = JavaCryptoProvider
         return community
     }
 

--- a/trustchain-explorer/src/main/java/nl/tudelft/trustchain/explorer/ui/blocks/BlocksFragment.kt
+++ b/trustchain-explorer/src/main/java/nl/tudelft/trustchain/explorer/ui/blocks/BlocksFragment.kt
@@ -23,7 +23,7 @@ import nl.tudelft.trustchain.common.util.viewBinding
 import nl.tudelft.trustchain.explorer.R
 import nl.tudelft.trustchain.explorer.databinding.FragmentBlocksBinding
 
-@UseExperimental(ExperimentalUnsignedTypes::class)
+@OptIn(ExperimentalUnsignedTypes::class)
 open class BlocksFragment : BaseFragment(R.layout.fragment_blocks) {
     private val adapter = ItemAdapter()
 


### PR DESCRIPTION
In this PR I updated the version of the `kotlin-ipv8` submodule to its latest commit (https://github.com/Tribler/kotlin-ipv8/commit/178acbb5cfeb015b3d3694daea86d957a963105a). I also fixed the errors as described in https://github.com/Tribler/kotlin-ipv8/issues/20.

Closes https://github.com/Tribler/kotlin-ipv8/issues/20