### PR TITLE
Use Java version 8 for CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 8
 
     - name: Run tests
       uses: eskatos/gradle-command-action@v1
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 8
 
       - name: Build debug APK
         run: bash ./gradlew assembleRelease


### PR DESCRIPTION
Using Java 11 for the build process is probably causing the following crash on Android 9. Using Java 8 should be a safer option.

```
Fatal Exception: java.lang.NoSuchMethodError: No virtual method flip()Ljava/nio/ByteBuffer; in class Ljava/nio/ByteBuffer; or its super classes (declaration of 'java.nio.ByteBuffer' appears in /system/framework/core-oj.jar)
       at nl.tudelft.ipv8.messaging.SerializationKt.deserializeLong(Serialization.kt:87)
       at nl.tudelft.ipv8.attestation.trustchain.payload.CrawlRequestPayload$Deserializer.deserialize(CrawlRequestPayload.kt:27)
       at nl.tudelft.ipv8.messaging.Packet.getAuthPayload(Packet.kt:35)
       at nl.tudelft.ipv8.attestation.trustchain.TrustChainCommunity.onCrawlRequestPacket(TrustChainCommunity.kt:330)
       at nl.tudelft.ipv8.attestation.trustchain.TrustChainCommunity.access$onCrawlRequestPacket(TrustChainCommunity.kt:27)
       at nl.tudelft.ipv8.attestation.trustchain.TrustChainCommunity$2.invoke(TrustChainCommunity.kt:43)
       at nl.tudelft.ipv8.attestation.trustchain.TrustChainCommunity$2.invoke(TrustChainCommunity.kt:27)
       at nl.tudelft.ipv8.Community.onPacket(Community.kt:143)
       at nl.tudelft.ipv8.messaging.Endpoint.notifyListeners(Endpoint.kt:28)
       at nl.tudelft.ipv8.messaging.EndpointAggregator.onPacket(EndpointAggregator.kt:75)
       at nl.tudelft.ipv8.messaging.Endpoint.notifyListeners(Endpoint.kt:28)
       at nl.tudelft.ipv8.messaging.udp.UdpEndpoint.handleReceivedPacket$ipv8(UdpEndpoint.kt:184)
       at nl.tudelft.ipv8.messaging.udp.UdpEndpoint$bindSocket$1.invokeSuspend(UdpEndpoint.kt:160)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:561)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:727)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:667)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:655)
```