### PR TITLE
Add message attachments, encryption

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,8 +71,8 @@ android {
         allWarningsAsErrors = true
     }
 
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding = true
     }
 
     packagingOptions {

--- a/app/src/main/java/nl/tudelft/trustchain/app/TrustChainApplication.kt
+++ b/app/src/main/java/nl/tudelft/trustchain/app/TrustChainApplication.kt
@@ -141,7 +141,7 @@ class TrustChainApplication : Application() {
         val randomWalk = RandomWalk.Factory()
         val store = PeerChatStore.getInstance(this)
         return OverlayConfiguration(
-            PeerChatCommunity.Factory(store),
+            PeerChatCommunity.Factory(store, this),
             listOf(randomWalk)
         )
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlint_gradle_version"
         classpath "com.squareup.sqldelight:gradle-plugin:$sqldelight_version"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,8 +38,8 @@ android {
         allWarningsAsErrors = true
     }
 
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding = true
     }
 
     testOptions {

--- a/common/src/test/java/nl/tudelft/trustchain/common/MarketCommunityTest.kt
+++ b/common/src/test/java/nl/tudelft/trustchain/common/MarketCommunityTest.kt
@@ -3,7 +3,6 @@ package nl.tudelft.trustchain.common
 import io.mockk.*
 import nl.tudelft.ipv8.Peer
 import nl.tudelft.ipv8.messaging.EndpointAggregator
-import nl.tudelft.ipv8.messaging.Serializable
 import nl.tudelft.ipv8.peerdiscovery.Network
 import nl.tudelft.trustchain.common.messaging.TradePayload
 import org.junit.Assert.assertEquals
@@ -20,12 +19,14 @@ class MarketCommunityTest {
     fun broadcast_callsSendOneTimePerPeer() {
         val payload = mockk<TradePayload>()
         every {
-            marketCommunity["serializePacket"](
-                any<Int>(),
-                any<Serializable>(),
-                any<Boolean>(),
-                any<Peer>(),
-                any<ByteArray>()
+            marketCommunity.serializePacket(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
             )
         } returns byteArrayOf(0x00)
         every { marketCommunity.getPeers() } returns getFakePeers()

--- a/peerchat/build.gradle
+++ b/peerchat/build.gradle
@@ -48,8 +48,8 @@ android {
         allWarningsAsErrors = true
     }
 
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding = true
     }
 }
 
@@ -85,6 +85,8 @@ dependencies {
     implementation 'com.github.tony19:logback-android:2.0.0'
 
     implementation 'com.mattskala:itemadapter:0.3'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
 
     // Testing
     testImplementation 'junit:junit:4.12'

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/community/AttachmentPayload.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/community/AttachmentPayload.kt
@@ -1,0 +1,30 @@
+package nl.tudelft.trustchain.peerchat.community
+
+import nl.tudelft.ipv8.messaging.*
+
+class AttachmentPayload(
+    val id: String,
+    val data: ByteArray
+) : Serializable {
+    override fun serialize(): ByteArray {
+        return serializeVarLen(id.toByteArray()) +
+            serializeVarLen(data)
+    }
+
+    companion object Deserializer : Deserializable<AttachmentPayload> {
+        override fun deserialize(buffer: ByteArray, offset: Int): Pair<AttachmentPayload, Int> {
+            var localOffset = offset
+            val (id, idSize) = deserializeVarLen(buffer, localOffset)
+            localOffset += idSize
+            val (data, dataSize) = deserializeVarLen(buffer, localOffset)
+            localOffset += dataSize
+            return Pair(
+                AttachmentPayload(
+                    id.toString(Charsets.UTF_8),
+                    data
+                ),
+                localOffset - offset
+            )
+        }
+    }
+}

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/community/AttachmentRequestPayload.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/community/AttachmentRequestPayload.kt
@@ -1,0 +1,23 @@
+package nl.tudelft.trustchain.peerchat.community
+
+import nl.tudelft.ipv8.messaging.*
+
+data class AttachmentRequestPayload(
+    val id: String
+) : Serializable {
+    override fun serialize(): ByteArray {
+        return serializeVarLen(id.toByteArray())
+    }
+
+    companion object Deserializer : Deserializable<AttachmentRequestPayload> {
+        override fun deserialize(buffer: ByteArray, offset: Int): Pair<AttachmentRequestPayload, Int> {
+            var localOffset = offset
+            val (id, idSize) = deserializeVarLen(buffer, localOffset)
+            localOffset += idSize
+            return Pair(
+                AttachmentRequestPayload(id.toString(Charsets.UTF_8)),
+                localOffset - offset
+            )
+        }
+    }
+}

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/community/MessagePayload.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/community/MessagePayload.kt
@@ -2,13 +2,19 @@ package nl.tudelft.trustchain.peerchat.community
 
 import nl.tudelft.ipv8.messaging.*
 
-data class MessagePayload(
+class MessagePayload constructor(
     val id: String,
-    val message: String
+    val message: String,
+    val attachmentType: String,
+    val attachmentSize: Long,
+    val attachmentContent: ByteArray
 ) : Serializable {
     override fun serialize(): ByteArray {
         return serializeVarLen(id.toByteArray()) +
-            serializeVarLen(message.toByteArray())
+            serializeVarLen(message.toByteArray()) +
+            serializeVarLen(attachmentType.toByteArray()) +
+            serializeLong(attachmentSize) +
+            serializeVarLen(attachmentContent)
     }
 
     companion object Deserializer : Deserializable<MessagePayload> {
@@ -18,8 +24,20 @@ data class MessagePayload(
             localOffset += idSize
             val (message, messageSize) = deserializeVarLen(buffer, localOffset)
             localOffset += messageSize
+            val (attachmentType, attachmentTypeSize) = deserializeVarLen(buffer, localOffset)
+            localOffset += attachmentTypeSize
+            val attachmentSize = deserializeLong(buffer, localOffset)
+            localOffset += SERIALIZED_LONG_SIZE
+            val (attachmentContent, attachmentContentSize) = deserializeVarLen(buffer, localOffset)
+            localOffset += attachmentContentSize
             return Pair(
-                MessagePayload(id.toString(Charsets.UTF_8), message.toString(Charsets.UTF_8)),
+                MessagePayload(
+                    id.toString(Charsets.UTF_8),
+                    message.toString(Charsets.UTF_8),
+                    attachmentType.toString(Charsets.UTF_8),
+                    attachmentSize,
+                    attachmentContent
+                ),
                 localOffset - offset
             )
         }

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/community/PeerChatCommunity.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/community/PeerChatCommunity.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.peerchat.community
 
+import android.content.Context
 import android.database.sqlite.SQLiteConstraintException
 import android.util.Log
 import kotlinx.coroutines.delay
@@ -9,23 +10,31 @@ import mu.KotlinLogging
 import nl.tudelft.ipv8.Community
 import nl.tudelft.ipv8.Overlay
 import nl.tudelft.ipv8.Peer
+import nl.tudelft.ipv8.keyvault.PrivateKey
 import nl.tudelft.ipv8.keyvault.PublicKey
 import nl.tudelft.ipv8.messaging.Packet
+import nl.tudelft.ipv8.util.hexToBytes
 import nl.tudelft.ipv8.util.toHex
 import nl.tudelft.trustchain.peerchat.db.PeerChatStore
 import nl.tudelft.trustchain.peerchat.entity.ChatMessage
+import nl.tudelft.trustchain.peerchat.ui.conversation.MessageAttachment
+import java.io.File
+import java.io.FileOutputStream
 import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
 class PeerChatCommunity(
-    private val database: PeerChatStore
+    private val database: PeerChatStore,
+    private val context: Context
 ) : Community() {
     override val serviceId = "ac9c01202e8d01e5f7d3cec88085dd842267c273"
 
     init {
         messageHandlers[MessageId.MESSAGE] = ::onMessagePacket
         messageHandlers[MessageId.ACK] = ::onAckPacket
+        messageHandlers[MessageId.ATTACHMENT_REQUEST] = ::onAttachmentRequestPacket
+        messageHandlers[MessageId.ATTACHMENT] = ::onAttachmentPacket
     }
 
     override fun load() {
@@ -33,31 +42,69 @@ class PeerChatCommunity(
 
         scope.launch {
             while (isActive) {
-                val messages = database.getUnacknowledgedMessages()
-                Log.d("PeerChat", "Found ${messages.size} outgoing unack messages")
-                messages.forEach { message ->
-                    sendMessage(message)
+                try {
+                    // Send unacknowledged messages
+                    val messages = database.getUnacknowledgedMessages()
+                    Log.d("PeerChat", "Found ${messages.size} outgoing unack messages")
+                    messages.forEach { message ->
+                        sendMessage(message)
+                    }
+
+                    // Request missing attachments
+                    val attachments = database.getUnfetchedAttachments()
+                    Log.d("PeerChat", "Found ${attachments.size} unfetched attachments")
+                    attachments.forEach { message ->
+                        val mid = message.sender.keyToHash().toHex()
+                        val peer = getPeers().find { it.mid == mid }
+                        if (peer != null && message.attachment != null) {
+                            sendAttachmentRequest(peer, message.attachment.content.toHex())
+                        }
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
                 }
-                delay(10000L)
+                delay(30000L)
             }
         }
     }
 
     fun sendMessage(message: String, recipient: PublicKey) {
-        val chatMessage = createOutgoingChatMessage(message, recipient)
+        val chatMessage = createOutgoingChatMessage(message, null, recipient)
+        database.addMessage(chatMessage)
+
+        sendMessage(chatMessage)
+    }
+
+    fun sendImage(file: File, recipient: PublicKey) {
+        val hash = file.name.hexToBytes()
+        val attachment = MessageAttachment(MessageAttachment.TYPE_IMAGE, file.length(), hash)
+        val chatMessage = createOutgoingChatMessage("", attachment, recipient)
         database.addMessage(chatMessage)
 
         sendMessage(chatMessage)
     }
 
     private fun sendMessage(chatMessage: ChatMessage) {
-        val payload = MessagePayload(chatMessage.id, chatMessage.message)
-        // TODO: encrypt
-        val packet = serializePacket(MessageId.MESSAGE, payload, true)
-
         val mid = chatMessage.recipient.keyToHash().toHex()
         val peer = getPeers().find { it.mid == mid }
+
         if (peer != null) {
+            val payload = MessagePayload(
+                chatMessage.id,
+                chatMessage.message,
+                chatMessage.attachment?.type ?: "",
+                chatMessage.attachment?.size ?: 0L,
+                chatMessage.attachment?.content ?: ByteArray(0)
+            )
+
+            val packet = serializePacket(
+                MessageId.MESSAGE,
+                payload,
+                sign = true,
+                encrypt = true,
+                recipient = peer
+            )
+
             logger.debug { "-> $payload" }
             send(peer, packet)
         } else {
@@ -72,8 +119,23 @@ class PeerChatCommunity(
         send(peer, packet)
     }
 
+    private fun sendAttachmentRequest(peer: Peer, id: String) {
+        val payload = AttachmentRequestPayload(id)
+        val packet = serializePacket(MessageId.ATTACHMENT_REQUEST, payload)
+        logger.debug { "-> $payload" }
+        send(peer, packet)
+    }
+
+    private fun sendAttachment(peer: Peer, id: String, file: File) {
+        val payload = AttachmentPayload(id, file.readBytes())
+        val packet = serializePacket(MessageId.ATTACHMENT, payload, encrypt = true, recipient = peer)
+        logger.debug { "-> $payload" }
+        send(peer, packet)
+    }
+
     private fun onMessagePacket(packet: Packet) {
-        val (peer, payload) = packet.getAuthPayload(MessagePayload.Deserializer)
+        val (peer, payload) = packet.getDecryptedAuthPayload(
+            MessagePayload.Deserializer, myPeer.key as PrivateKey)
         logger.debug { "<- $payload" }
         onMessage(peer, payload)
     }
@@ -82,6 +144,19 @@ class PeerChatCommunity(
         val (peer, payload) = packet.getAuthPayload(AckPayload.Deserializer)
         logger.debug { "<- $payload" }
         onAck(peer, payload)
+    }
+
+    private fun onAttachmentRequestPacket(packet: Packet) {
+        val (peer, payload) = packet.getAuthPayload(AttachmentRequestPayload.Deserializer)
+        logger.debug { "<- $payload" }
+        onAttachmentRequest(peer, payload)
+    }
+
+    private fun onAttachmentPacket(packet: Packet) {
+        val (_, payload) = packet.getDecryptedAuthPayload(
+            AttachmentPayload.Deserializer, myPeer.key as PrivateKey)
+        logger.debug { "<- $payload" }
+        onAttachment(payload)
     }
 
     private fun onMessage(peer: Peer, payload: MessagePayload) {
@@ -96,6 +171,11 @@ class PeerChatCommunity(
 
         Log.d("PeerChat", "Sending ack to ${chatMessage.id}")
         sendAck(peer, chatMessage.id)
+
+        // Request attachment
+        if (chatMessage.attachment != null) {
+            sendAttachmentRequest(peer, chatMessage.attachment.content.toHex())
+        }
     }
 
     private fun onAck(peer: Peer, payload: AckPayload) {
@@ -108,43 +188,100 @@ class PeerChatCommunity(
         }
     }
 
-    private fun createOutgoingChatMessage(message: String, recipient: PublicKey): ChatMessage {
+    private fun onAttachmentRequest(peer: Peer, payload: AttachmentRequestPayload) {
+        try {
+            val file = MessageAttachment.getFile(context, payload.id)
+            if (file.exists()) {
+                sendAttachment(peer, payload.id, file)
+            } else {
+                Log.w("PeerChat", "The requested attachment does not exist")
+            }
+        } catch (e: SQLiteConstraintException) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun onAttachment(payload: AttachmentPayload) {
+        try {
+            val file = MessageAttachment.getFile(context, payload.id)
+            if (!file.exists()) {
+                // Save attachment
+                val os = FileOutputStream(file)
+                os.write(payload.data)
+            }
+            // Mark attachment as fetched
+            database.setAttachmentFetched(payload.id)
+        } catch (e: SQLiteConstraintException) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun createOutgoingChatMessage(
+        message: String,
+        attachment: MessageAttachment?,
+        recipient: PublicKey
+    ): ChatMessage {
         val id = UUID.randomUUID().toString()
         return ChatMessage(
             id,
             message,
+            attachment,
             myPeer.publicKey,
             recipient,
             true,
             Date(),
             ack = false,
-            read = true
+            read = true,
+            attachmentFetched = true
         )
     }
 
     private fun createIncomingChatMessage(peer: Peer, message: MessagePayload): ChatMessage {
+        /*
+        // Store attachment
+        val file = if (message.attachmentData.isNotEmpty())
+            saveFile(context, message.attachmentData) else null
+         */
+
         return ChatMessage(
             message.id,
             message.message,
+            createMessageAttachment(message),
             peer.publicKey,
             myPeer.publicKey,
             false,
             Date(),
             ack = false,
-            read = false
+            read = false,
+            attachmentFetched = false
         )
+    }
+
+    private fun createMessageAttachment(message: MessagePayload): MessageAttachment? {
+        return if (message.attachmentType.isNotEmpty()) {
+            MessageAttachment(
+                message.attachmentType,
+                message.attachmentSize,
+                message.attachmentContent
+            )
+        } else {
+            null
+        }
     }
 
     object MessageId {
         const val MESSAGE = 1
         const val ACK = 2
+        const val ATTACHMENT_REQUEST = 3
+        const val ATTACHMENT = 4
     }
 
     class Factory(
-        private val database: PeerChatStore
+        private val database: PeerChatStore,
+        private val context: Context
     ) : Overlay.Factory<PeerChatCommunity>(PeerChatCommunity::class.java) {
         override fun create(): PeerChatCommunity {
-            return PeerChatCommunity(database)
+            return PeerChatCommunity(database, context)
         }
     }
 }

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/entity/ChatMessage.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/entity/ChatMessage.kt
@@ -1,6 +1,7 @@
 package nl.tudelft.trustchain.peerchat.entity
 
 import nl.tudelft.ipv8.keyvault.PublicKey
+import nl.tudelft.trustchain.peerchat.ui.conversation.MessageAttachment
 import java.util.*
 
 data class ChatMessage(
@@ -13,6 +14,11 @@ data class ChatMessage(
      * The message content.
      */
     val message: String,
+
+    /**
+     * An optional message attachment.
+     */
+    val attachment: MessageAttachment?,
 
     /**
      * The public key of the message sender.
@@ -40,7 +46,12 @@ data class ChatMessage(
     val ack: Boolean,
 
     /**
-     * True if the message has been read.
+     * True if the message has been read (for incoming messages).
      */
-    val read: Boolean
+    val read: Boolean,
+
+    /**
+     * True if the attachment has been fetched and stored locally (for incoming messages).
+     */
+    val attachmentFetched: Boolean
 )

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/ui/conversation/ChatMessageItemRenderer.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/ui/conversation/ChatMessageItemRenderer.kt
@@ -6,6 +6,7 @@ import android.text.format.DateUtils
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.isVisible
+import com.bumptech.glide.Glide
 import com.mattskala.itemadapter.ItemLayoutRenderer
 import kotlinx.android.synthetic.main.item_message.view.*
 import nl.tudelft.trustchain.common.util.getColorByHash
@@ -32,11 +33,30 @@ class ChatMessageItemRenderer : ItemLayoutRenderer<ChatMessageItem, View>(
         avatar.isVisible = item.shouldShowAvatar
         imgDelivered.isVisible = item.chatMessage.outgoing && item.chatMessage.ack
         constraintSet.clone(constraintLayout)
-        constraintSet.removeFromHorizontalChain(txtMessage.id)
+        constraintSet.removeFromHorizontalChain(content.id)
         constraintSet.removeFromHorizontalChain(bottomContainer.id)
+
+        val attachment = item.chatMessage.attachment
+        if (attachment != null && attachment.type == MessageAttachment.TYPE_IMAGE) {
+            val file = attachment.getFile(view.context)
+            if (file.exists()) {
+                Glide.with(view).load(file).into(image)
+                progress.isVisible = false
+            } else {
+                image.setImageBitmap(null)
+                progress.isVisible = true
+            }
+            image.isVisible = true
+            txtMessage.isVisible = false
+        } else {
+            image.isVisible = false
+            txtMessage.isVisible = true
+            progress.isVisible = false
+        }
+
         if (item.chatMessage.outgoing) {
             constraintSet.connect(
-                txtMessage.id,
+                content.id,
                 ConstraintSet.END,
                 ConstraintSet.PARENT_ID,
                 ConstraintSet.END
@@ -51,7 +71,7 @@ class ChatMessageItemRenderer : ItemLayoutRenderer<ChatMessageItem, View>(
             val avatarMargin = resources.getDimensionPixelSize(R.dimen.avatar_size) +
                 resources.getDimensionPixelSize(R.dimen.avatar_margin)
             constraintSet.connect(
-                txtMessage.id,
+                content.id,
                 ConstraintSet.START,
                 ConstraintSet.PARENT_ID,
                 ConstraintSet.START,

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/ui/conversation/MessageAttachment.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/ui/conversation/MessageAttachment.kt
@@ -1,0 +1,56 @@
+package nl.tudelft.trustchain.peerchat.ui.conversation
+
+import android.content.Context
+import nl.tudelft.ipv8.util.toHex
+import java.io.File
+
+@OptIn(ExperimentalUnsignedTypes::class)
+data class MessageAttachment constructor(
+    /**
+     * The type of the attachment. Currently, only "image" is supported.
+     */
+    val type: String,
+
+    /**
+     * The size of the attachment in bytes.
+     */
+    val size: Long,
+
+    /**
+     * The hash of the attachment that can be used for retrieving its data.
+     */
+    val content: ByteArray
+) {
+    fun getFile(context: Context): File {
+        return getFile(context, content.toHex())
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MessageAttachment
+
+        if (type != other.type) return false
+        if (size != other.size) return false
+        if (!content.contentEquals(other.content)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = type.hashCode()
+        result = 31 * result + size.hashCode()
+        result = 31 * result + content.contentHashCode()
+        return result
+    }
+
+    companion object {
+        const val TYPE_IMAGE = "image"
+
+        fun getFile(context: Context, id: String): File {
+            val path = "" + context.filesDir + "/" + id
+            return File(path)
+        }
+    }
+}

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/ui/conversation/RichEditText.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/ui/conversation/RichEditText.kt
@@ -1,0 +1,29 @@
+package nl.tudelft.trustchain.peerchat.ui.conversation
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
+import androidx.appcompat.R
+import androidx.core.view.inputmethod.EditorInfoCompat
+import androidx.core.view.inputmethod.InputConnectionCompat
+
+class RichEditText @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.editTextStyle
+) : androidx.appcompat.widget.AppCompatEditText(context, attrs, defStyleAttr) {
+    var onCommitContentListener: InputConnectionCompat.OnCommitContentListener? = null
+
+    override fun onCreateInputConnection(editorInfo: EditorInfo): InputConnection {
+        val ic: InputConnection = super.onCreateInputConnection(editorInfo)
+        EditorInfoCompat.setContentMimeTypes(editorInfo, arrayOf("image/*"))
+
+        val callback = InputConnectionCompat.OnCommitContentListener {
+                inputContentInfo, flags, opts ->
+            onCommitContentListener?.onCommitContent(inputContentInfo, flags, opts) ?: false
+        }
+
+        return InputConnectionCompat.createWrapper(ic, editorInfo, callback)
+    }
+}

--- a/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/util/FileUtils.kt
+++ b/peerchat/src/main/java/nl/tudelft/trustchain/peerchat/util/FileUtils.kt
@@ -1,0 +1,23 @@
+package nl.tudelft.trustchain.peerchat.util
+
+import android.content.Context
+import android.net.Uri
+import nl.tudelft.ipv8.util.sha256
+import nl.tudelft.ipv8.util.toHex
+import nl.tudelft.trustchain.peerchat.ui.conversation.MessageAttachment
+import java.io.*
+
+fun saveFile(context: Context, uri: Uri): File {
+    val inputStream = context.contentResolver.openInputStream(uri)
+    val bytes = inputStream!!.readBytes()
+    return saveFile(context, bytes)
+}
+
+fun saveFile(context: Context, bytes: ByteArray): File {
+    val id = sha256(bytes).toHex()
+    val file = MessageAttachment.getFile(context, id)
+    val outputStream = FileOutputStream(file)
+    outputStream.write(bytes)
+    outputStream.close()
+    return file
+}

--- a/peerchat/src/main/res/drawable/ic_baseline_add_photo_alternate_24.xml
+++ b/peerchat/src/main/res/drawable/ic_baseline_add_photo_alternate_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,7v2.99s-1.99,0.01 -2,0L17,7h-3s0.01,-1.99 0,-2h3L17,2h2v3h3v2h-3zM16,11L16,8h-3L13,5L5,5c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2v-8h-3zM5,19l3,-4 2,3 3,-4 4,5L5,19z"/>
+</vector>

--- a/peerchat/src/main/res/layout/fragment_conversation.xml
+++ b/peerchat/src/main/res/layout/fragment_conversation.xml
@@ -19,17 +19,31 @@
         android:layout_height="wrap_content"
         android:padding="8dp">
 
-        <EditText
+        <ImageButton
+            android:id="@+id/btnAddImage"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:src="@drawable/ic_baseline_add_photo_alternate_24"
+            android:background="@drawable/circle_step"
+            android:tint="@color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <nl.tudelft.trustchain.peerchat.ui.conversation.RichEditText
             android:id="@+id/edtMessage"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
             android:textSize="14sp"
             android:padding="16dp"
             android:background="@drawable/bg_field"
-            android:inputType="textCapSentences|text"
+            android:inputType="textCapSentences|textMultiLine"
             android:hint="Write a message..."
             android:paddingEnd="56dp"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btnAddImage"
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <ImageButton
             android:id="@+id/btnSend"

--- a/peerchat/src/main/res/layout/item_message.xml
+++ b/peerchat/src/main/res/layout/item_message.xml
@@ -17,20 +17,37 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/txtMessage"
+    <FrameLayout
+        android:id="@+id/content"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:minWidth="50dp"
-        android:background="@drawable/bg_message"
-        android:textColor="@color/text_primary"
-        android:paddingTop="12dp"
-        android:paddingBottom="12dp"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:text="Lorem Ipsum" />
+        app:layout_constraintStart_toStartOf="parent">
+
+        <TextView
+            android:id="@+id/txtMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="50dp"
+            android:background="@drawable/bg_message"
+            android:textColor="@color/text_primary"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            tools:text="Lorem Ipsum" />
+
+        <ProgressBar
+            android:id="@+id/progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+        <ImageView
+            android:id="@+id/image"
+            android:layout_width="200dp"
+            android:layout_height="200dp" />
+    </FrameLayout>
 
     <LinearLayout
         android:id="@+id/bottomContainer"
@@ -40,8 +57,8 @@
         android:gravity="center"
         android:paddingTop="2dp"
         android:paddingBottom="4dp"
-        app:layout_constraintTop_toBottomOf="@id/txtMessage"
-        app:layout_constraintStart_toStartOf="@id/txtMessage">
+        app:layout_constraintTop_toBottomOf="@id/content"
+        app:layout_constraintStart_toStartOf="@id/content">
 
         <ImageView
             android:id="@+id/imgDelivered"

--- a/peerchat/src/main/sqldelight/1.sqm
+++ b/peerchat/src/main/sqldelight/1.sqm
@@ -1,0 +1,4 @@
+ALTER TABLE messages ADD COLUMN attachment_type TEXT;
+ALTER TABLE messages ADD COLUMN attachment_size INTEGER;
+ALTER TABLE messages ADD COLUMN attachment_content BLOB;
+ALTER TABLE messages ADD COLUMN attachment_fetched INTEGER NOT NULL DEFAULT 0;

--- a/peerchat/src/main/sqldelight/nl/tudelft/peerchat/sqldelight/DbMessage.sq
+++ b/peerchat/src/main/sqldelight/nl/tudelft/peerchat/sqldelight/DbMessage.sq
@@ -7,12 +7,16 @@ CREATE TABLE messages (
     timestamp INTEGER NOT NULL,
     ack INTEGER NOT NULL,
     read INTEGER NOT NULL,
+    attachment_type TEXT,
+    attachment_size INTEGER,
+    attachment_content BLOB,
+    attachment_fetched INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (id)
 );
 
 addMessage:
-INSERT INTO messages (id, message, sender_public_key, recipient_public_key, outgoing, timestamp, ack, read)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO messages (id, message, sender_public_key, recipient_public_key, outgoing, timestamp, ack, read, attachment_type, attachment_size, attachment_content, attachment_fetched)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 ackMessage:
 UPDATE messages SET ack = 1 WHERE id = ?;
@@ -27,9 +31,15 @@ ORDER BY timestamp ASC;
 getUnacknowledgedMessages:
 SELECT * FROM messages WHERE ack = 0 AND outgoing = 1;
 
+getUnfetchedAttachments:
+SELECT * FROM messages WHERE attachment_fetched = 0 AND outgoing = 0;
+
 ack:
 UPDATE messages SET ack = 1 WHERE id = ?;
 
 getLastByPublicKey:
 SELECT * FROM messages WHERE sender_public_key = ? OR recipient_public_key = ?
 ORDER BY timestamp DESC LIMIT 1;
+
+setAttachmentFetched:
+UPDATE messages SET attachment_fetched = 1 WHERE attachment_content = ?;

--- a/trustchain-explorer/build.gradle
+++ b/trustchain-explorer/build.gradle
@@ -45,8 +45,8 @@ android {
         allWarningsAsErrors = true
     }
 
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding = true
     }
 }
 


### PR DESCRIPTION
A message can include an optional attachment consisting of type, size, and id (the hash of its content). The recipient can then request the attachment by sending an attachment request including the attachment id.

Messages and attachments are now E2E encrypted.

<img src="https://user-images.githubusercontent.com/1122874/83972304-ac4b2280-a8df-11ea-9d61-105096996186.png" height=500>