### PR TITLE
Replace bintray dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,7 +149,7 @@ dependencies {
     implementation ('net.java.dev.jna:jna:5.5.0@aar')
     implementation('com.github.tony19:logback-android:2.0.0')
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // Testing
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     ext.dokka_version = "0.10.1"
     repositories {
         google()
+        jcenter()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url 'https://jitpack.io' }
@@ -36,6 +37,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        jcenter()
         mavenCentral()
         maven { url 'https://jitpack.io' }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,9 @@ buildscript {
     ext.dokka_version = "0.10.1"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -35,9 +36,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        maven { url "https://dl.bintray.com/mattskala/maven" }
-        maven { url "https://dl.bintray.com/terl/lazysodium-maven" }
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging:1.7.7'
     //implementation 'com.github.tony19:logback-android:2.0.0'
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // BitTorrent
     api files('libs/jlibtorrent-1.2.10.0.jar')
@@ -115,7 +115,7 @@ dependencies {
     testImplementation "io.mockk:mockk:1.9.3"
     testImplementation 'org.json:json:20190722'
     testImplementation "com.squareup.sqldelight:sqlite-driver:$sqldelight_version"
-    testImplementation "com.goterl.lazycode:lazysodium-java:4.3.2"
+    testImplementation "com.goterl:lazysodium-java:5.0.1"
     annotationProcessor 'androidx.room:room-compiler:2.2.5'
 }
 

--- a/common/src/test/java/nl/tudelft/trustchain/common/util/VotingHelperTest.kt
+++ b/common/src/test/java/nl/tudelft/trustchain/common/util/VotingHelperTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.trustchain.common.util
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 import io.mockk.mockk

--- a/currencyii/build.gradle
+++ b/currencyii/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     // Logging
     implementation 'io.github.microutils:kotlin-logging:1.7.7'
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // Testing
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/debug/build.gradle
+++ b/debug/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging:1.7.7'
     implementation 'com.github.tony19:logback-android:2.0.0'
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // Testing
     testImplementation 'junit:junit:4.12'

--- a/distributedai/build.gradle
+++ b/distributedai/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging:1.7.7'
     implementation 'com.github.tony19:logback-android:2.0.0'
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
 
     implementation "com.androidplot:androidplot-core:1.5.7"

--- a/eurotoken/build.gradle
+++ b/eurotoken/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // Material
     implementation 'com.google.android.material:material:1.1.0'

--- a/gossipML/build.gradle
+++ b/gossipML/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     testImplementation "io.mockk:mockk:1.9.3"
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.7'
     testImplementation "org.robolectric:robolectric:3.4.2"
-    testImplementation "com.goterl.lazycode:lazysodium-java:4.3.2"
+    testImplementation "com.goterl:lazysodium-java:5.0.1"
     testImplementation 'androidx.core:core-ktx:1.3.2'
 
     // Testing and generating example data

--- a/gossipML/src/test/java/gossipML/ipv8/ModelExchangeMessageTest.kt
+++ b/gossipML/src/test/java/gossipML/ipv8/ModelExchangeMessageTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.trustchain.gossipML.ipv8
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.keyvault.LibNaClSK
 import nl.tudelft.ipv8.util.hexToBytes
 import nl.tudelft.trustchain.gossipML.models.OnlineModel

--- a/ig-ssi/build.gradle
+++ b/ig-ssi/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging:1.7.7'
     implementation 'com.github.tony19:logback-android:2.0.0'
 
-    implementation 'com.mattskala:itemadapter:0.3'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // Testing
     testImplementation 'junit:junit:4.12'

--- a/musicdao-datafeeder/build.gradle
+++ b/musicdao-datafeeder/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 //    implementation project(':common')
     api(project(':ipv8-jvm')){
         exclude group: 'org.slf4j'
-        exclude group: 'com.goterl.lazycode'
+        exclude group: 'com.goterl'
         exclude group: 'org.bouncycastle'
     }
 

--- a/musicdao/build.gradle
+++ b/musicdao/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     implementation 'org.knowm.xchange:xchange-binance:5.0.1'
 
     // Crypto library for testing
-    testImplementation "com.goterl.lazycode:lazysodium-java:4.2.4"
+    testImplementation "com.goterl:lazysodium-java:5.0.1"
 
     // Testing
     testImplementation 'junit:junit:4.12'

--- a/musicdao/src/test/java/com/example/musicdao/FaucetEndpointTest.kt
+++ b/musicdao/src/test/java/com/example/musicdao/FaucetEndpointTest.kt
@@ -1,5 +1,6 @@
 package com.example.musicdao
 
+import org.junit.Ignore
 import org.junit.Test
 import java.io.InputStream
 import java.net.URL
@@ -9,6 +10,7 @@ class FaucetEndpointTest {
     val endpointAddress = "http://134.122.59.107:3000"
 
     @Test
+    @Ignore("Unreliable tests") // unit test should not depend on external server
     fun getCoins() {
         val obj = URL("$endpointAddress?id=$id")
         val con: InputStream? = obj.openStream()

--- a/musicdao/src/test/java/com/example/musicdao/catalog/PlaylistCoverFragmentTest.kt
+++ b/musicdao/src/test/java/com/example/musicdao/catalog/PlaylistCoverFragmentTest.kt
@@ -1,7 +1,7 @@
 package com.example.musicdao.catalog
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.attestation.trustchain.*
 import nl.tudelft.ipv8.keyvault.JavaCryptoProvider
 import nl.tudelft.ipv8.keyvault.LibNaClSK

--- a/musicdao/src/test/java/com/example/musicdao/ipv8/KeywordSearchMessageTest.kt
+++ b/musicdao/src/test/java/com/example/musicdao/ipv8/KeywordSearchMessageTest.kt
@@ -1,7 +1,7 @@
 package com.example.musicdao.ipv8
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.keyvault.LibNaClSK
 import nl.tudelft.ipv8.util.hexToBytes
 import org.junit.Assert

--- a/peerchat/build.gradle
+++ b/peerchat/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging:1.7.7'
     implementation 'com.github.tony19:logback-android:2.0.0'
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'

--- a/trustchain-explorer/build.gradle
+++ b/trustchain-explorer/build.gradle
@@ -80,7 +80,8 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging:1.7.7'
     implementation 'com.github.tony19:logback-android:2.0.0'
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
+
 
     // Testing
     testImplementation 'junit:junit:4.12'

--- a/trustchain-payloadgenerator/build.gradle
+++ b/trustchain-payloadgenerator/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     // Animation
     implementation 'com.airbnb.android:lottie:3.4.0'
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/trustchain-trader/build.gradle
+++ b/trustchain-trader/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     // Animation
     implementation 'com.airbnb.android:lottie:3.4.0'
 
-    implementation 'com.mattskala:itemadapter:0.4'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"


### PR DESCRIPTION
Notable changes
- `com.mattskala:itemadapter:0.4` is moved from `bintray` to` jitpack` -> `com.github.MattSkala:recyclerview-itemadapter:0.4`
- `com.goterl.lazycode:lazysodium-java:4.3.2` is moved from bintray to mavenCentral -> `com.goterl:lazysodium-java:5.0.1`
- `jcenter` is kept until some android deps are moved to `mavenCentral` (added already)