### PR TITLE
Android 12 Bluetooth Permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,22 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <!--BLUETOOTH PERMISSION-->
+    <!-- Request legacy Bluetooth permissions on older devices. -->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <!-- Needed only if your app looks for Bluetooth devices.
+             If your app doesn't use Bluetooth scan results to derive physical
+             location information, you can strongly assert that your app
+             doesn't derive physical location. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <!-- Needed only if your app makes the device discoverable to Bluetooth
+      devices. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <!-- Needed only if your app communicates with already-paired Bluetooth
+           devices. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
     <application
         android:name="nl.tudelft.trustchain.app.TrustChainApplication"
         android:allowBackup="true"

--- a/app/src/main/java/nl/tudelft/trustchain/app/TrustChainApplication.kt
+++ b/app/src/main/java/nl/tudelft/trustchain/app/TrustChainApplication.kt
@@ -51,7 +51,6 @@ import nl.tudelft.trustchain.peerchat.community.PeerChatCommunity
 import nl.tudelft.trustchain.peerchat.db.PeerChatStore
 import nl.tudelft.trustchain.valuetransfer.community.IdentityCommunity
 import nl.tudelft.trustchain.valuetransfer.db.IdentityStore
-
 import nl.tudelft.trustchain.voting.VotingCommunity
 import nl.tudelft.gossipML.sqldelight.Database as MLDatabase
 
@@ -61,10 +60,15 @@ class TrustChainApplication : Application() {
         super.onCreate()
 
         defaultCryptoProvider = AndroidCryptoProvider
-        initIPv8()
+
+        // Only start IPv8 here if we are on Android 11 or below.
+        val BUILD_VERSION_CODE_S = 31
+        if (Build.VERSION.SDK_INT < BUILD_VERSION_CODE_S) {
+            initIPv8()
+        }
     }
 
-    private fun initIPv8() {
+    fun initIPv8() {
         val config = IPv8Configuration(
             overlays = listOf(
                 createDiscoveryCommunity(),

--- a/app/src/main/java/nl/tudelft/trustchain/app/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/nl/tudelft/trustchain/app/ui/dashboard/DashboardActivity.kt
@@ -1,30 +1,61 @@
 package nl.tudelft.trustchain.app.ui.dashboard
 
+import android.app.AlertDialog
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.GridLayoutManager
 import com.mattskala.itemadapter.ItemAdapter
+import nl.tudelft.ipv8.android.IPv8Android
 import nl.tudelft.trustchain.app.AppDefinition
+import nl.tudelft.trustchain.app.R
+import nl.tudelft.trustchain.app.TrustChainApplication
 import nl.tudelft.trustchain.app.databinding.ActivityDashboardBinding
 import nl.tudelft.trustchain.common.util.viewBinding
 
+@RequiresApi(Build.VERSION_CODES.M)
 class DashboardActivity : AppCompatActivity() {
     private val binding by viewBinding(ActivityDashboardBinding::inflate)
 
     private val adapter = ItemAdapter()
 
-    init {
+    private val BLUETOOTH_PERMISSIONS_REQUEST_CODE = 200
+    private val SETTINGS_INTENT_CODE = 1000
+
+    private val BLUETOOTH_PERMISSIONS_SCAN = "android.permission.BLUETOOTH_SCAN"
+    private val BLUETOOTH_PERMISSIONS_CONNECT = "android.permission.BLUETOOTH_CONNECT"
+    private val BLUETOOTH_PERMISSIONS_ADVERTISE = "android.permission.BLUETOOTH_ADVERTISE"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Handle init of IPv8 after requesting permissions; only if Android 12 or higher.
+        // onPermissionsDenied() is run until user has accepted permissions.
+        val BUILD_VERSION_CODE_S = 31
+        if (Build.VERSION.SDK_INT >= BUILD_VERSION_CODE_S) {
+            if (!hasBluetoothPermissions()) {
+                requestBluetoothPermissions()
+            } else {
+                // Only initialize IPv8 if it has not been initialized yet.
+                try {
+                    IPv8Android.getInstance()
+                } catch (exception: Exception) {
+                    (application as TrustChainApplication).initIPv8()
+                }
+            }
+        }
+
         adapter.registerRenderer(
             DashboardItemRenderer {
                 val intent = Intent(this, it.app.activity)
                 startActivity(intent)
             }
         )
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
 
         setContentView(binding.root)
 
@@ -40,5 +71,70 @@ class DashboardActivity : AppCompatActivity() {
         return AppDefinition.values().map {
             DashboardItem(it)
         }
+    }
+
+    private fun hasBluetoothPermissions(): Boolean {
+        return checkSelfPermission(BLUETOOTH_PERMISSIONS_ADVERTISE) == PackageManager.PERMISSION_GRANTED &&
+            checkSelfPermission(BLUETOOTH_PERMISSIONS_CONNECT) == PackageManager.PERMISSION_GRANTED &&
+            checkSelfPermission(BLUETOOTH_PERMISSIONS_SCAN) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun requestBluetoothPermissions() {
+        requestPermissions(
+            arrayOf(
+                BLUETOOTH_PERMISSIONS_ADVERTISE,
+                BLUETOOTH_PERMISSIONS_CONNECT,
+                BLUETOOTH_PERMISSIONS_SCAN
+            ), BLUETOOTH_PERMISSIONS_REQUEST_CODE
+        )
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        when (requestCode) {
+            BLUETOOTH_PERMISSIONS_REQUEST_CODE -> {
+                if (hasBluetoothPermissions()) {
+                    (application as TrustChainApplication).initIPv8()
+                } else {
+                    onPermissionsDenied()
+                }
+            }
+            else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        when (requestCode) {
+            SETTINGS_INTENT_CODE -> {
+                if (hasBluetoothPermissions()) {
+                    (application as TrustChainApplication).initIPv8()
+                } else {
+                    onPermissionsDenied()
+                }
+            }
+            else -> super.onActivityResult(requestCode, resultCode, data)
+        }
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    private fun onPermissionsDenied() {
+        AlertDialog.Builder(this)
+            .setMessage(getString(R.string.permissions_denied_message))
+            .apply {
+                setPositiveButton(getString(R.string.permissions_denied_ok_button)) { _, _ ->
+                    run {
+                        val intent =
+                            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                        val uri: Uri = Uri.fromParts("package", packageName, null)
+                        intent.data = uri
+                        startActivityForResult(intent, SETTINGS_INTENT_CODE)
+                    }
+                }.create()
+            }
+            .show()
+            .setCanceledOnTouchOutside(false)
     }
 }

--- a/app/src/main/java/nl/tudelft/trustchain/app/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/nl/tudelft/trustchain/app/ui/dashboard/DashboardActivity.kt
@@ -85,7 +85,8 @@ class DashboardActivity : AppCompatActivity() {
                 BLUETOOTH_PERMISSIONS_ADVERTISE,
                 BLUETOOTH_PERMISSIONS_CONNECT,
                 BLUETOOTH_PERMISSIONS_SCAN
-            ), BLUETOOTH_PERMISSIONS_REQUEST_CODE
+            ),
+            BLUETOOTH_PERMISSIONS_REQUEST_CODE
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="permissions_denied_message">You have denied the permissions, please go to settings to enable them or close the app.</string>
+    <string name="permissions_denied_ok_button">OPEN SETTINGS</string>
+</resources>


### PR DESCRIPTION
Behavior on Android 11 and below should be the exact same. On Android 12 Bluetooth permissions should be requested on runtime:
- User is requested for Bluetooth permissions on dashboard load
- If user denies; an alert will block the application permanently with a button going to the Settings page for user to enable permissions
<details><summary>Prompt</summary>
![2](https://user-images.githubusercontent.com/16310635/154495531-2de40259-0aa9-42a7-bb7d-8e877b0c62f7.png)
</details>

Unfortunately need to work with our own prompt since you can only request for permissions 2 times during the whole app lifecycle now: https://developer.android.com/about/versions/11/privacy/permissions#dialog-visibility

Tested on my emulators but not on any active installation so not sure if upgrade will work seamlessly; this needs to be tested before merging.
