### PR TITLE
Use correct transaction input + fix little-endian conversion

### DIFF
--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/taproot/CTransaction.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/taproot/CTransaction.kt
@@ -377,11 +377,19 @@ val OP_EQUAL = CScriptOp(0x87)
 val OP_1 = CScriptOp(0x51)
 const val ANNEX_TAG = 0x50.toByte()
 
-fun littleEndian(bigChungus: BigInteger): ByteArray {
-    val bb: ByteBuffer = ByteBuffer.allocate(bigChungus.toByteArray().size)
+fun littleEndian(i: BigInteger): ByteArray {
+    val bb: ByteBuffer = ByteBuffer.allocate(i.toByteArray().size)
     bb.order(ByteOrder.BIG_ENDIAN)
-    bb.put(bigChungus.toByteArray())
-    return bb.array().reversedArray().copyOfRange(0, 4)
+    bb.put(i.toByteArray())
+
+    val littleEndian = bb.array().reversedArray()
+    return if (littleEndian.size > 3) {
+        littleEndian.copyOfRange(0, 4)
+    } else {
+        val output = ByteArray(4)
+        littleEndian.forEachIndexed { index, byte -> output[index] = byte }
+        output
+    }
 }
 
 fun serUint256(u_in: BigInteger): ByteArray {


### PR DESCRIPTION
This PR makes bugfixes to the Luxury Communism module.

- Previously only the user's wallet was actually used as an input to the transaction belonging to the join action of a new member. Consequently, this required the user to have a balance of the entire DAOs worth + the entrance fee. Now the previous shared wallet is correctly used as an input.
- The little-endian conversion falsely assumed that the number always consisted of four bytes, leading to crashes in the instance that the number consisted of fewer bytes.