### PR TITLE
Use dataset to seed lots of Creative Commons music

### DIFF
--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/HiltModules.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/HiltModules.kt
@@ -119,9 +119,10 @@ class HiltModules {
     @Singleton
     fun downloadFinishUseCase(
         database: CacheDatabase,
-        cachePath: CachePath
+        cachePath: CachePath,
+        @ApplicationContext applicationContext: Context
     ): DownloadFinishUseCase {
-        return DownloadFinishUseCase(database = database, cachePath = cachePath)
+        return DownloadFinishUseCase(database = database, cachePath = cachePath, context = applicationContext)
     }
 
     @Provides

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/MusicActivity.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/MusicActivity.kt
@@ -26,6 +26,7 @@ import nl.tudelft.trustchain.musicdao.ui.MusicDAOApp
 import nl.tudelft.trustchain.musicdao.ui.screens.profile.ProfileScreenViewModel
 import nl.tudelft.trustchain.musicdao.ui.screens.release.ReleaseScreenViewModel
 import com.frostwire.jlibtorrent.SessionManager
+import com.frostwire.jlibtorrent.TorrentStatus
 import com.google.common.util.concurrent.Service
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -81,6 +82,10 @@ class MusicActivity : AppCompatActivity() {
             setupMusicCommunity.registerListeners()
             albumRepository.refreshCache()
             torrentEngine.seedStrategy()
+
+            // download creative common music metadata
+            val magnetUri = getString(R.string.bootstrap_cc_music_metadata);
+            torrentEngine.download(magnetUri);
         }
         iterativelyFetchReleases()
         Intent(this, MusicGossipingService::class.java).also { intent ->

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/entities/AlbumEntity.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/entities/AlbumEntity.kt
@@ -28,7 +28,7 @@ data class AlbumEntity(
             title = title,
             artist = artist,
             publisher = publisher,
-            releaseDate = Instant.parse(releaseDate),
+            releaseDate = if (releaseDate.isNotEmpty()) Instant.parse(releaseDate) else Instant.now(),
             songs = songs.map { it.toSong() },
             cover =
                 cover?.let { path ->

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/torrent/fileProcessing/DownloadFinishUseCase.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/torrent/fileProcessing/DownloadFinishUseCase.kt
@@ -34,7 +34,7 @@ class DownloadFinishUseCase(
                     val songMetadata = line.split('|');
                     database.dao.insert(
                         AlbumEntity(
-                            id = "pandacd-" + songMetadata[0],
+                            id = "cc:pandacd-" + songMetadata[0],
                             magnet = songMetadata[2],
                             title = songMetadata[0].substringAfter(" – ").substringBefore(" ["),
                             artist = songMetadata[1],

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/torrent/fileProcessing/DownloadFinishUseCase.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/torrent/fileProcessing/DownloadFinishUseCase.kt
@@ -1,17 +1,21 @@
 package nl.tudelft.trustchain.musicdao.core.torrent.fileProcessing
 
+import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import nl.tudelft.trustchain.musicdao.CachePath
+import nl.tudelft.trustchain.musicdao.R
 import nl.tudelft.trustchain.musicdao.core.cache.CacheDatabase
+import nl.tudelft.trustchain.musicdao.core.cache.entities.AlbumEntity
 import nl.tudelft.trustchain.musicdao.core.cache.entities.SongEntity
 import java.nio.file.Paths
 
 class DownloadFinishUseCase(
     private val database: CacheDatabase,
-    private val cachePath: CachePath
+    private val cachePath: CachePath,
+    private val context: Context,
 ) {
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
 
@@ -19,41 +23,76 @@ class DownloadFinishUseCase(
         coroutineScope.launch {
             Log.d("MusicDao", "DownloadFinishUseCase: $infoHash")
 
-            // TODO: fix, multiple releases can potentially have some info-hash, will break
-            val albumEntities = database.dao.getFromInfoHash(infoHash)
+            val metadataInfoHash = magnetToInfoHash(context.getString(R.string.bootstrap_cc_music_metadata));
+            if (infoHash == metadataInfoHash) {
+                val data = Paths.get("${cachePath.getPath()}/torrents/$infoHash");
 
-            for (albumEntity in albumEntities) {
-                if (albumEntity.isDownloaded) {
-                    Log.d("MusicDao", "DownloadFinishUseCase: Skipping $infoHash of ${albumEntity.id}, already downloaded")
-                }
+                val metadata = data.resolve("metadata.psv").toFile()
 
-                val root = Paths.get("${cachePath.getPath()}/torrents/$infoHash")
-
-                val mp3Files = FileProcessor.getMP3Files(root)
-                Log.d("MusicDao", "DownloadFinishUseCase: mp3 files in $root: $mp3Files")
-
-                val songs =
-                    mp3Files?.map {
-                        SongEntity(
-                            file = it.filename,
-                            title = FileProcessor.getTitle(it),
-                            artist = albumEntity.artist
+                val lines = metadata.readLines()
+                for (line in lines) {
+                    val songMetadata = line.split('|');
+                    database.dao.insert(
+                        AlbumEntity(
+                            id = "pandacd-" + songMetadata[0],
+                            magnet = songMetadata[2],
+                            title = songMetadata[0].substringAfter(" – ").substringBefore(" ["),
+                            artist = songMetadata[1],
+                            publisher = "creative commons",
+                            releaseDate = songMetadata[0].substringBeforeLast("] ").substringAfterLast(" [") + "-01-01T00:00:00Z",
+                            songs = listOf(),
+                            cover = null,
+                            root = null,
+                            isDownloaded = false,
+                            infoHash = magnetToInfoHash(songMetadata[2]),
+                            torrentPath = null
                         )
-                    } ?: listOf()
-
-                val cover = FileProcessor.getCoverArt(root)
-                val updatedAlbumEntity =
-                    albumEntity.copy(
-                        songs = songs,
-                        cover = cover?.absolutePath,
-                        root = root.toString(),
-                        isDownloaded = true,
-                        torrentPath = Paths.get("${cachePath.getPath()}/torrents/$infoHash.torrent").toString()
                     )
+                }
+            } else {
+                // TODO: fix, multiple releases can potentially have some info-hash, will break
+                val albumEntities = database.dao.getFromInfoHash(infoHash)
 
-                Log.d("MusicDao", "DownloadFinishUseCase: updated album with $updatedAlbumEntity")
-                database.dao.update(updatedAlbumEntity)
+                for (albumEntity in albumEntities) {
+                    if (albumEntity.isDownloaded) {
+                        Log.d("MusicDao", "DownloadFinishUseCase: Skipping $infoHash of ${albumEntity.id}, already downloaded")
+                    }
+
+                    val root = Paths.get("${cachePath.getPath()}/torrents/$infoHash")
+
+                    val mp3Files = FileProcessor.getMP3Files(root)
+                    Log.d("MusicDao", "DownloadFinishUseCase: mp3 files in $root: $mp3Files")
+
+                    val songs =
+                        mp3Files?.map {
+                            SongEntity(
+                                file = it.filename,
+                                title = FileProcessor.getTitle(it),
+                                artist = albumEntity.artist
+                            )
+                        } ?: listOf()
+
+                    val cover = FileProcessor.getCoverArt(root)
+                    val updatedAlbumEntity =
+                        albumEntity.copy(
+                            songs = songs,
+                            cover = cover?.absolutePath,
+                            root = root.toString(),
+                            isDownloaded = true,
+                            torrentPath = Paths.get("${cachePath.getPath()}/torrents/$infoHash.torrent").toString()
+                        )
+
+                    Log.d("MusicDao", "DownloadFinishUseCase: updated album with $updatedAlbumEntity")
+                    database.dao.update(updatedAlbumEntity)
+                }
             }
         }
+    }
+
+    fun magnetToInfoHash(magnet: String): String? {
+        val mark = "magnet:?xt=urn:btih:"
+        val start = magnet.indexOf(mark) + mark.length
+        if (start == -1) return null
+        return magnet.substring(20, start + 40)
     }
 }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreen.kt
@@ -247,11 +247,13 @@ fun Header(
             style = MaterialTheme.typography.body2.merge(SpanStyle(fontWeight = FontWeight.SemiBold)),
             modifier = Modifier.padding(bottom = 5.dp)
         )
-        Text(
-            "Artist Public Key",
-            style = MaterialTheme.typography.body2.merge(SpanStyle(fontWeight = FontWeight.SemiBold)),
-            modifier = Modifier.padding(bottom = 5.dp)
-        )
+        if (!album.id.startsWith("cc:")) {
+            Text(
+                "Artist Public Key",
+                style = MaterialTheme.typography.body2.merge(SpanStyle(fontWeight = FontWeight.SemiBold)),
+                modifier = Modifier.padding(bottom = 5.dp)
+            )
+        }
         Text(
             album.publisher,
             style = MaterialTheme.typography.body2.merge(SpanStyle(fontWeight = FontWeight.SemiBold)),
@@ -278,29 +280,31 @@ fun Header(
                         contentDescription = null
                     )
                 }
-                IconButton(
-                    onClick = {
-                        navController.navigate(
-                            Screen.Profile.createRoute(publicKey = album.publisher)
+                if (!album.id.startsWith("cc:")) {
+                    IconButton(
+                        onClick = {
+                            navController.navigate(
+                                Screen.Profile.createRoute(publicKey = album.publisher)
+                            )
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Person,
+                            contentDescription = null
                         )
                     }
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Person,
-                        contentDescription = null
-                    )
-                }
-                IconButton(
-                    onClick = {
-                        navController.navigate(
-                            Screen.Donate.createRoute(publicKey = album.publisher)
+                    IconButton(
+                        onClick = {
+                            navController.navigate(
+                                Screen.Donate.createRoute(publicKey = album.publisher)
+                            )
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ShoppingCart,
+                            contentDescription = null
                         )
                     }
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.ShoppingCart,
-                        contentDescription = null
-                    )
                 }
 
                 var expanded by remember { mutableStateOf(false) }
@@ -315,23 +319,25 @@ fun Header(
                         expanded = expanded,
                         onDismissRequest = { expanded = false }
                     ) {
-                        DropdownMenuItem(
-                            onClick = {
-                                navController.navigate(
-                                    Screen.Profile.createRoute(publicKey = album.publisher)
-                                )
+                        if (!album.id.startsWith("cc:")) {
+                            DropdownMenuItem(
+                                onClick = {
+                                    navController.navigate(
+                                        Screen.Profile.createRoute(publicKey = album.publisher)
+                                    )
+                                }
+                            ) {
+                                Text("View Artist")
                             }
-                        ) {
-                            Text("View Artist")
-                        }
-                        DropdownMenuItem(
-                            onClick = {
-                                navController.navigate(
-                                    Screen.Donate.createRoute(publicKey = album.publisher)
-                                )
+                            DropdownMenuItem(
+                                onClick = {
+                                    navController.navigate(
+                                        Screen.Donate.createRoute(publicKey = album.publisher)
+                                    )
+                                }
+                            ) {
+                                Text("Donate")
                             }
-                        ) {
-                            Text("Donate")
                         }
                         DropdownMenuItem(onClick = { }) {
                             Text("View Meta-data")

--- a/musicdao/src/main/res/values/strings.xml
+++ b/musicdao/src/main/res/values/strings.xml
@@ -2,5 +2,6 @@
 <resources>
     <string name="app_label">MusicDAO</string>
     <string name="search_hint">Search through music</string>
+    <string name="bootstrap_cc_music_metadata">magnet:?xt=urn:btih:acaf6367a327fb2b68315baaf0d27b4fb7611c4c&amp;xt=urn:btmh:1220db9d7935c342b00b8e5fdb8380fe5d8e6a0e9b7d40ff41a9955f95093d1c7a27&amp;dn=metadata.psv&amp;xl=82730&amp;tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&amp;tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce</string>
 </resources>
 


### PR DESCRIPTION
The implementation relies on a torrent that contains all metadata for the Creative Commons music scraped from [https://pandacd.io/](https://pandacd.io/) with [https://github.com/brian2509/pandacd-scrape](https://github.com/brian2509/pandacd-scrape).

Torrent magnet: magnet:?xt=urn:btih:acaf6367a327fb2b68315baaf0d27b4fb7611c4c&xt=urn:btmh:1220db9d7935c342b00b8e5fdb8380fe5d8e6a0e9b7d40ff41a9955f95093d1c7a27&dn=metadata.psv&xl=82730&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce

Potential issues:
- Most albums on pandacd don't have the public key addresses of their publishers
- It seems that sometimes seeding the metadata corrupts the metadata and all albums are linked to the same torrent file, clearing all the data of the app fixes the issue

![image](https://github.com/user-attachments/assets/181e8c94-0d5b-44e7-85b2-5fd09f2004bd)
![image](https://github.com/user-attachments/assets/f459f7bb-38d8-48e6-b0fc-ab3fb4d57980)
![image](https://github.com/user-attachments/assets/0d0b995e-027f-4dd8-8123-a40366427257)


